### PR TITLE
Fix `bleach` dependencies

### DIFF
--- a/recipes-python/python3-bleach_3.1.5.bb
+++ b/recipes-python/python3-bleach_3.1.5.bb
@@ -11,7 +11,8 @@ PYPI_PACKAGE = "bleach"
 
 RDEPENDS_${PN} += " \
         ${PYTHON_PN}-six \
-        ${PYTHON_PN}-html5lib \
+        ${PYTHON_PN}-webencodings \
+        ${PYTHON_PN}-packaging \
         bash \
         "
 


### PR DESCRIPTION
### Issue

Currently, building `packagegroup-python3-jupyter` succeeds but running jupyter notebooks (ie `jupyter notebook`) fails because of a missing runtime dependency in the recipe for `bleach`.

### Cause

Python package `bleach` was updated in [version 3.1.5](https://pypi.org/project/bleach/3.1.5/) to have `packaging` as a dependency. 

### Changes
This PR adds `packaging` as an RDEPENDS of `bleach`. It also updates the dependency `html5lib` to `webencodings` since `webencodings` is the actual dependency of `bleach` (`html5lib` includes `webencodings`).

### Testing
With the changes in this PR, `packagegroup-python3-jupyter` still builds successfully, `packaging` is included in python site-packages on the device, and the jupyter notebook starts successfully.

