### PR TITLE
python3-anyio: added missing dependency

### DIFF
--- a/recipes-python/python3-anyio_3.4.0.bb
+++ b/recipes-python/python3-anyio_3.4.0.bb
@@ -10,6 +10,7 @@ SRC_URI:append = " \
 "
 
 DEPENDS += " \
+	python3-setuptools-scm-native \
 	python3-wheel-native \
 	python3-pip-native \
 "


### PR DESCRIPTION
Added dependency to prevent fetching it in the compile step.

Signed-off-by: Jan Vermaete <jan.vermaete@gmail.com>