### PR TITLE
fix dependency on meta-python in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ This layer depends on:
 	URI: https://git.openembedded.org/openembedded-core
 	layers: meta, meta-poky
 
-	URI: https://git.openembedded.org/meta-python2
-	branch: master or xilinx current release version (e.g. hosister)
+	URI: https://git.openembedded.org/meta-openembedded
+	layers: meta-python
 


### PR DESCRIPTION
Hi Xilinx-team,

I'm using your layer and recently updated to kirkstone.
Then I noticed that the README is out of date as it still lists the dependency on meta-python2.

Here is a tiny fix for that.

I was not quite sure about your branch workflow, so I just created a PR against the `master` branch.
The change would also apply to `langdale`, `langdale-next` and `kirkstone-next`.

Regards,
Tobias